### PR TITLE
feat: add Linux platform support for Android SDK skins path 🐧

### DIFF
--- a/UpdateSkinPaths.js
+++ b/UpdateSkinPaths.js
@@ -20,8 +20,10 @@ if (platform === "win32") {
   );
 } else if (platform === "darwin") {
   baseSkinPath = path.join(userHome, "Library", "Android", "sdk", "skins");
+} else if (platform == "linux") {
+  baseSkinPath = path.join(userHome, "Android", "Sdk", "skins");
 }
-
+ 
 // Define the source skins directory
 const skinsSourcePath = path.join(xmlDirectory, "skins");
 


### PR DESCRIPTION
Adds Linux platform detection in UpdateSkinPaths.js with default path ~/Android/Sdk/skins, keeping compatibility with Windows and macOS.